### PR TITLE
Writing corrupt PNG file on windows.

### DIFF
--- a/yuml
+++ b/yuml
@@ -36,7 +36,7 @@ class Request():
     def prepout(self):
         "Open the output file."
         if self.opts.outfile:
-            self.out = open(self.opts.outfile, 'w')
+            self.out = open(self.opts.outfile, 'wb')
         else:
             print "Usage: yuml [-i FILE] -o FILE"
             sys.exit(1)


### PR DESCRIPTION
The PNG written in windows (python 2.7.1) with 'w' was writing
a corrupt PNG file. Changing the open mode to 'wb' fixes this.
