### PR TITLE
Update script to skip empty lines in input file

### DIFF
--- a/yuml
+++ b/yuml
@@ -28,7 +28,7 @@ class Request():
         if f == '-':
             self.body = [x.decode('utf8') for x in sys.stdin.readlines()]
         elif os.path.exists(f):
-            self.body = [x.strip() for x in codecs.open(f, 'r', 'utf-8').readlines()]
+            self.body = [x.strip() for x in codecs.open(f, 'r', 'utf-8').readlines() if x.strip()]
         else:
             raise IOError(u"File %s not found" % f)
         self.log(u'Done reading.')


### PR DESCRIPTION
Previously the script would fail if an input file included empty lines.
This has been fixed by only parsing lines that contain characters other
than whitespace.
